### PR TITLE
Enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }


### PR DESCRIPTION
Enable assertions so that we can use "assert" in the code.
Fix #24 